### PR TITLE
RH6: Removed unwanted modules during LIS upgrade

### DIFF
--- a/LISISO/upgrade.sh
+++ b/LISISO/upgrade.sh
@@ -89,6 +89,12 @@ if [[ $distro_version != "5"* ]]; then
 fi
 
 cd ${targetDir}
+
+if [[ $distro_version != "7"* ]]; then
+	# Remove conflicting module before installation
+	RemoveConflictingModules
+fi
+
 # Invoke the release specific install script
 echo "Invoking release specific install file in directory ${targetDir}"
 ./upgrade.sh


### PR DESCRIPTION
This modification is required to remove the unwanted modules when LIS is upgraded without installation.

Fixes: d67b88d67 ("RH7: Dynamic detection of LIS compatibility with installed kernel")